### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:yakkety
+FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y \
         curl \


### PR DESCRIPTION
Yakkety does not appear to work with Babel 7
I couldn't debug further as this Dockerfile no longer builds as support has been dropped for Yakkety.